### PR TITLE
update deps

### DIFF
--- a/src/plugins.txt
+++ b/src/plugins.txt
@@ -1,8 +1,8 @@
-blueocean:1.6.2
+blueocean:1.7.1
 configuration-as-code:experimental
 credentials-binding:1.16
 git:3.9.1
 github-oauth:0.29
 http_request:1.8.22
-kubernetes:1.9.2
+kubernetes:1.10.1
 pipeline-utility-steps:2.1.0


### PR DESCRIPTION
This should stop Jenkins from yelling at you over old plugins.



These changes are tested.