### PR TITLE
updating all out-of-date jenkins plugins

### DIFF
--- a/src/plugins.txt
+++ b/src/plugins.txt
@@ -1,8 +1,8 @@
-blueocean:1.7.1
+blueocean:1.7.2
 configuration-as-code:experimental
 credentials-binding:1.16
 git:3.9.1
 github-oauth:0.29
 http_request:1.8.22
-kubernetes:1.10.1
+kubernetes:1.12.3
 pipeline-utility-steps:2.1.0


### PR DESCRIPTION
Was able to test that updating these plugins did not negatively impact Jenkins by running a local instance of Jenkins (using [this](https://github.com/Skookum/jenkins-k8s) helm chart) on my local minikube cluster.